### PR TITLE
Jump-to-definition functionality is now available.

### DIFF
--- a/core/corvus-behaviour.el
+++ b/core/corvus-behaviour.el
@@ -97,6 +97,13 @@
 (add-hook 'prog-mode-hook #'company-mode)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Jump-to-definition configurations.                                     ;;;;
+;;;;     - Functionality for jump-to-definitions via dumb-jump and AG.      ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(add-hook 'xref-backend-functions #'dumb-jump-xref-activate)
+(setq-default dumb-jump-prefer-searcher 'ag)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; Minor mode to lock buffers to a window.                                ;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/core/corvus-packages.el
+++ b/core/corvus-packages.el
@@ -42,6 +42,7 @@
     crux
     diff-hl
     diminish
+    dumb-jump
     expand-region
     flycheck
     highlight-indent-guides

--- a/docs/core/behaviour.md
+++ b/docs/core/behaviour.md
@@ -197,3 +197,27 @@ all major groups contained in `prog-mode`.
 ```elisp
 (add-hook 'prog-mode-hook #'company-mode)
 ```
+
+## Jump-to-definition functionality
+
+Jump-to-definition is achieved thanks to the `dumb-jump` package and the `ag`
+search engine. Once `dumb-jump` is installed, simply bind the `xref` 
+keybindings to the ones that correspond to `xref`.
+
+```elisp
+(add-hook 'xref-backend-functions #'dumb-jump-xref-activate)
+```
+
+When working on a git-based project, the search engine `git-grep` is used. In
+other cases, `ag`, `grep`, and `ack` can be used. Corvus prefers `ag` when
+working on projects that aren't git-based.
+
+```elisp
+(setq-default dumb-jump-prefer-searcher 'ag)
+```
+
+The basic keybindings are the following:
+
+| Keybinding | Description                                  |
+| `M-.`      | Go to definition of function, variable, etc. |
+| `M-,`      | Return to the previous point before jumping. |

--- a/docs/core/packages.md
+++ b/docs/core/packages.md
@@ -24,6 +24,8 @@ All of these packages can be found on MELPA.
 |                  |                                                         |
 | Diminish         | Properly hide specified minor modes from the mode-line. |
 |                  |                                                         |
+| Dumb Jump        | Jump-to-Definition functionality.                       |
+|                  |                                                         |
 | Expand Region    | Smart expanding system, useful to select words.         |
 |                  |                                                         |
 | Flycheck         | Spell-checking on the fly as one types.                 |


### PR DESCRIPTION
Thanks to `dumb-jump` and `AG`, Corvus can now jump to definitions of functions, variables, classes, etc.